### PR TITLE
Add auto-resume flag in slurm.yaml

### DIFF
--- a/recipes_collection/cluster/slurm.yaml
+++ b/recipes_collection/cluster/slurm.yaml
@@ -6,6 +6,7 @@ job_name_prefix: 'sagemaker-'
 slurm_create_submission_file_only: False # Setting to True if just want to create submission file
 stderr_to_stdout: True # Setting to False to split the stderr and stdout logs
 srun_args:
+  - --auto-resume=1
   # - "--no-container-mount-home"
 slurm_docker_cfg:
   docker_args:


### PR DESCRIPTION
So that HyperPod can auto-resume from H/W failures

## Description

### Motivation
Explain the motivation

### Changes
* List your changes

### Testing
Explain how the changes were tested

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [ ] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [ ] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [ ] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [ ] I have run `pytest` on my code and all unit tests passed.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
