### PR TITLE
fix trainig.yaml did not render requiredDuringSchedulingIgnoredDuring

### DIFF
--- a/launcher/nemo/k8s_templates/training/training.yaml
+++ b/launcher/nemo/k8s_templates/training/training.yaml
@@ -103,23 +103,23 @@ spec:
           affinity:
             nodeAffinity:
             {{- if $config.labelSelector.required }}
-              {{- range $key, $values := $config.labelSelector.required }}
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
+                    {{- range $key, $values := $config.labelSelector.required }}
                     - key: {{ $key | quote }}
                       operator: In
                       values:
                         {{- range $values }}
                         - {{ . | quote }}
                         {{- end}}
-              {{- end }}
+                    {{- end }}
             {{- end }}
 
             {{- if $config.labelSelector.preferred }}
               {{- $index := 0 }}
-              {{- range $key, $values := $config.labelSelector.preferred }}
               preferredDuringSchedulingIgnoredDuringExecution:
+                {{- range $key, $values := $config.labelSelector.preferred }}
                 - weight: {{ index $config.labelSelector.weights $index }}
                   preference:
                     matchExpressions:
@@ -129,8 +129,8 @@ spec:
                           {{- range $values }}
                           - {{ . | quote }}
                           {{- end }}
-              {{- $index = add $index 1 }}
-              {{- end }}
+                {{- $index = add $index 1 }}
+                {{- end }}
             {{- end }}
           {{- end }}
 

--- a/tests/k8s_workflow/k8s_baseline_artifacts/llama-8b/k8s_template/templates/training.yaml
+++ b/tests/k8s_workflow/k8s_baseline_artifacts/llama-8b/k8s_template/templates/training.yaml
@@ -103,23 +103,23 @@ spec:
           affinity:
             nodeAffinity:
             {{- if $config.labelSelector.required }}
-              {{- range $key, $values := $config.labelSelector.required }}
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
+                    {{- range $key, $values := $config.labelSelector.required }}
                     - key: {{ $key | quote }}
                       operator: In
                       values:
                         {{- range $values }}
                         - {{ . | quote }}
                         {{- end}}
-              {{- end }}
+                    {{- end }}
             {{- end }}
 
             {{- if $config.labelSelector.preferred }}
               {{- $index := 0 }}
-              {{- range $key, $values := $config.labelSelector.preferred }}
               preferredDuringSchedulingIgnoredDuringExecution:
+                {{- range $key, $values := $config.labelSelector.preferred }}
                 - weight: {{ index $config.labelSelector.weights $index }}
                   preference:
                     matchExpressions:
@@ -129,8 +129,8 @@ spec:
                           {{- range $values }}
                           - {{ . | quote }}
                           {{- end }}
-              {{- $index = add $index 1 }}
-              {{- end }}
+                {{- $index = add $index 1 }}
+                {{- end }}
             {{- end }}
           {{- end }}
 

--- a/tests/k8s_workflow/k8s_baseline_artifacts/test_custom/k8s_template/templates/training.yaml
+++ b/tests/k8s_workflow/k8s_baseline_artifacts/test_custom/k8s_template/templates/training.yaml
@@ -103,23 +103,23 @@ spec:
           affinity:
             nodeAffinity:
             {{- if $config.labelSelector.required }}
-              {{- range $key, $values := $config.labelSelector.required }}
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
+                    {{- range $key, $values := $config.labelSelector.required }}
                     - key: {{ $key | quote }}
                       operator: In
                       values:
                         {{- range $values }}
                         - {{ . | quote }}
                         {{- end}}
-              {{- end }}
+                    {{- end }}
             {{- end }}
 
             {{- if $config.labelSelector.preferred }}
               {{- $index := 0 }}
-              {{- range $key, $values := $config.labelSelector.preferred }}
               preferredDuringSchedulingIgnoredDuringExecution:
+                {{- range $key, $values := $config.labelSelector.preferred }}
                 - weight: {{ index $config.labelSelector.weights $index }}
                   preference:
                     matchExpressions:
@@ -129,8 +129,8 @@ spec:
                           {{- range $values }}
                           - {{ . | quote }}
                           {{- end }}
-              {{- $index = add $index 1 }}
-              {{- end }}
+                {{- $index = add $index 1 }}
+                {{- end }}
             {{- end }}
           {{- end }}
 


### PR DESCRIPTION
## Description

Fix trainig.yaml did not render requiredDuringSchedulingIgnoredDuring. Related issue #27 

### Motivation

The issue related to requiredDuringSchedulingIgnoredDuring did not render correctly.

```
            requiredDuringSchedulingIgnoredDuringExecution:
                nodeSelectorTerms:
                  - matchExpressions:
                    - key: "beta.kubernetes.io/instance-type"
                      operator: In
                      values:
                        - "ml.p4d.24xlarge"
              requiredDuringSchedulingIgnoredDuringExecution:
                nodeSelectorTerms:
                  - matchExpressions:
                    - key: "sagemaker.amazonaws.com/node-health-status"
                      operator: In
                      values:
                        - "Schedulable"
 ```
should be

```
            requiredDuringSchedulingIgnoredDuringExecution:
                nodeSelectorTerms:
                  - matchExpressions:
                    - key: "beta.kubernetes.io/instance-type"
                      operator: In
                      values:
                        - "ml.p4d.24xlarge"
                    - key: "sagemaker.amazonaws.com/node-health-status"
                      operator: In
                      values:
                        - "Schedulable"
```

### Changes
* Fix requiredDuringSchedulingIgnoredDuringExecution loop render place

### Testing
Explain how the changes were tested

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [x] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [x] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [x] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [x] I have run `pytest` on my code and all unit tests passed.
 - [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
