### PR TITLE
Fix dictionary type cluster parameters in k8s template yaml

### DIFF
--- a/launcher/nemo/stages.py
+++ b/launcher/nemo/stages.py
@@ -13,6 +13,7 @@
 # Portions taken from https://github.com/NVIDIA/NeMo-Framework-Launcher, Copyright Nvidia Corporation
 
 
+from ast import literal_eval
 import logging
 import shutil
 from pathlib import Path
@@ -694,13 +695,13 @@ class SMTraining(Training):
         if cluster_parameters.get("namespace", None) is not None:
             values_template.trainingConfig.namespace = cluster_parameters["namespace"]
         if cluster_parameters.get("annotations", None) is not None:
-            values_template.trainingConfig.annotations = cluster_parameters["annotations"]
+            values_template.trainingConfig.annotations = literal_eval(cluster_parameters["annotations"])
         if cluster_parameters.get("priority_class_name", None) is not None:
             values_template.trainingConfig.priorityClassName = cluster_parameters["priority_class_name"]
         if cluster_parameters.get("service_account_name") is not None:
             values_template.trainingConfig.serviceAccountName = cluster_parameters["service_account_name"]
         if cluster_parameters.get("custom_labels", None) is not None:
-            values_template.trainingConfig.customLabels = cluster_parameters["custom_labels"]
+            values_template.trainingConfig.customLabels = literal_eval(cluster_parameters["custom_labels"])
         if cluster_parameters.get("label_selector", None) is not None:
             values_template.trainingConfig.labelSelector = cluster_parameters["label_selector"]
         values_template.trainingConfig.compile = OmegaConf.select(self.cfg, "recipes.run.compile", default=0)


### PR DESCRIPTION
## Description
Some cluster parameters like annotations and custom labels are dictionaries, but when using hyperpod CLI we have to write these dicts as strings. Currently we are writing these strings directly to k8s template yaml like this:
```
annotations: '{''sagemaker.amazonaws.com/enable-job-auto-resume'': True, ''sagemaker.amazonaws.com/job-max-retry-count'': 1}' 
```
This is not the correct yaml format and leads to job creation failures

### Motivation
Fix a bug reported by SA

### Changes
Use ast.literal_eval() rather to deserialize strings of annotations and custom labels to dicts.

### Testing
Run
```
hyperpod start-job --auto-resume true --namespace default --recipe fine-tuning/deepseek/hf_deepseek_r1_distilled_qwen_14b_seq8k_gpu_fine_tuning
```
Now it's generating correct k8s template yaml:
```
annotations:
    sagemaker.amazonaws.com/enable-job-auto-resume: true
    sagemaker.amazonaws.com/job-max-retry-count: 1
```

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [ ] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [ ] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [ ] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [ ] I have run `pytest` on my code and all unit tests passed.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
