### PR TITLE
Fix nova g5 sft lora recipe

### DIFF
--- a/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_12x_gpu_lora_sft.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_12x_gpu_lora_sft.yaml
@@ -13,7 +13,7 @@ run:
 
 ## Training specific configs
 training_config:
-  max_length: 8196               # Maximum context window size (tokens). Should be between [1024, 8192] and multiple of 1024.
+  max_length: 8192               # Maximum context window size (tokens). Should be between [1024, 8192] and multiple of 1024.
   global_batch_size: 64           # Global batch size, allowed values are 16, 32, 64
 
   trainer:


### PR DESCRIPTION
## Description

### Motivation
Fixed the Nova micro G5 LoRA SFT recipe by:

* Correcting the max_length parameter from 8196 to 8192

### Changes
* Correcting the max_length parameter from 8196 to 8192

### Testing
Change has been tested in SMTJ.

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [x] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [x] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [ ] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [x] I have run `pytest` on my code and all unit tests passed.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
