### PR TITLE
Add support for instance_type field for nova models

### DIFF
--- a/launcher/efa.py
+++ b/launcher/efa.py
@@ -169,3 +169,33 @@ instanceWithRDMASupport = set(
         "trn2.48xlarge",
     ]
 )
+
+INSTANCE_TO_DEVICE_COUNT = {
+    "g4dn.xlarge": 1,
+    "g4dn.2xlarge": 1,
+    "g4dn.4xlarge": 1,
+    "g4dn.8xlarge": 1,
+    "g4dn.12xlarge": 4,
+    "g4dn.16xlarge": 1,
+    "g5.xlarge": 1,
+    "g5.2xlarge": 1,
+    "g5.4xlarge": 1,
+    "g5.8xlarge": 1,
+    "g5.12xlarge": 4,
+    "g5.16xlarge": 1,
+    "g5.24xlarge": 4,
+    "g6.xlarge": 1,
+    "g6.2xlarge": 1,
+    "g6.4xlarge": 1,
+    "g6.8xlarge": 1,
+    "g6.12xlarge": 4,
+    "g6.16xlarge": 1,
+    "g6.24xlarge": 4,
+    "g6e.xlarge": 1,
+    "g6e.2xlarge": 1,
+    "g6e.4xlarge": 1,
+    "g6e.8xlarge": 1,
+    "g6e.12xlarge": 2,
+    "g6e.16xlarge": 1,
+    "g6e.24xlarge": 4,
+}

--- a/launcher/nova/constants/init_container_constants.py
+++ b/launcher/nova/constants/init_container_constants.py
@@ -1,2 +1,2 @@
-INIT_CONTAINER_REGION_ACCOUNT_MAP = {"us-east-1": "708977205387"}
+INIT_CONTAINER_REGION_ACCOUNT_MAP = {"us-east-1": "900867814919"}
 INIT_CONTAINER_IMAGE_URI = "{account_id}.dkr.ecr.{region}.amazonaws.com/init-container-repo:latest"

--- a/launcher_scripts/nova/run_nova_micro_g5_12x_gpu_lora_sft.sh
+++ b/launcher_scripts/nova/run_nova_micro_g5_12x_gpu_lora_sft.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_micro_g5_12x_gpu_lora_sft \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/tests/nova_k8s_workflow/k8s_baseline_artifacts/nova-lite-sft/k8s_templates/values.yaml
+++ b/tests/nova_k8s_workflow/k8s_baseline_artifacts/nova-lite-sft/k8s_templates/values.yaml
@@ -27,7 +27,8 @@ trainingConfig:
   cleanPodPolicy: null
   initContainer:
     name: init-container
-    image: 708977205387.dkr.ecr.us-east-1.amazonaws.com/init-container-repo:latest
+    image: 900867814919.dkr.ecr.us-east-1.amazonaws.com/init-container-repo:latest
     env: []
   envVars:
     X_AMZ_SOURCE_ACCOUNT: '123456789012'
+    INSTANCE_TYPE: ml.p5.48xlarge

--- a/tests/nova_k8s_workflow/test_nova_ppo_recipe_k8s_workflow.py
+++ b/tests/nova_k8s_workflow/test_nova_ppo_recipe_k8s_workflow.py
@@ -18,6 +18,13 @@ ppo_run_name = "nova-lite-ppo"
 
 
 @pytest.fixture(autouse=True)
+def mock_aws_account_id():
+    with patch("launcher.nova.launchers.boto3.client") as mock_boto_client:
+        mock_boto_client.return_value.get_caller_identity.return_value = {"Account": "123456789012"}
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_aws_region():
     session_mock = MagicMock()
     session_mock.region_name = "us-east-1"


### PR DESCRIPTION
## Description

### Motivation
To support G4/g5 or any other instance types we need to take instance_type as an input from clid config or cluster config and use it to set kubernetes node type. Also taking setting EFA devices in values based on node type.

### Changes
* Add get instance_type from config and use it to set num of EFA devices and k8s node type.
* Correct test cases.

### Testing
python -m pytest,

launched a pytorch job successfully.



## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [x] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [ ] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [ ] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [x] I have run `pytest` on my code and all unit tests passed.
 - [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
