### PR TITLE
Add Nova recipes for g5/g6 instance type for Micro/lite model types

### DIFF
--- a/launcher_scripts/nova/run_nova_lite_g5_g6_12x_gpu_lora_sft.sh
+++ b/launcher_scripts/nova/run_nova_lite_g5_g6_12x_gpu_lora_sft.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_lite_g5_g6_12x_gpu_lora_sft \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_lite_g5_g6_48x_gpu_lora_dpo.sh
+++ b/launcher_scripts/nova/run_nova_lite_g5_g6_48x_gpu_lora_dpo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_lite_g5_g6_48x_gpu_lora_dpo \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_lite_g5_g6_48x_gpu_lora_sft.sh
+++ b/launcher_scripts/nova/run_nova_lite_g5_g6_48x_gpu_lora_sft.sh
@@ -4,5 +4,5 @@ set -e
 SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
 
 HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
-    recipes=fine-tuning/nova/nova_micro_g5_12x_gpu_lora_sft \
+    recipes=fine-tuning/nova/nova_lite_g5_g6_48x_gpu_lora_sft \
     base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_micro_g5_g6_12x_gpu_lora_dpo.sh
+++ b/launcher_scripts/nova/run_nova_micro_g5_g6_12x_gpu_lora_dpo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_micro_g5_g6_12x_gpu_lora_dpo \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_micro_g5_g6_12x_gpu_lora_sft.sh
+++ b/launcher_scripts/nova/run_nova_micro_g5_g6_12x_gpu_lora_sft.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_micro_g5_g6_12x_gpu_lora_sft \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_micro_g5_g6_48x_gpu_lora_dpo.sh
+++ b/launcher_scripts/nova/run_nova_micro_g5_g6_48x_gpu_lora_dpo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_micro_g5_g6_48x_gpu_lora_dpo \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_micro_g5_g6_48x_gpu_lora_sft.sh
+++ b/launcher_scripts/nova/run_nova_micro_g5_g6_48x_gpu_lora_sft.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_micro_g5_g6_48x_gpu_lora_sft \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/launcher_scripts/nova/run_nova_micro_g5_g6_48x_gpu_sft.sh
+++ b/launcher_scripts/nova/run_nova_micro_g5_g6_48x_gpu_sft.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+SAGEMAKER_TRAINING_LAUNCHER_DIR=${SAGEMAKER_TRAINING_LAUNCHER_DIR:-"$(pwd)"}
+
+HYDRA_FULL_ERROR=1 python3 "${SAGEMAKER_TRAINING_LAUNCHER_DIR}/main.py" \
+    recipes=fine-tuning/nova/nova_micro_g5_g6_48x_gpu_sft \
+    base_results_dir="${SAGEMAKER_TRAINING_LAUNCHER_DIR}/results"

--- a/recipes_collection/recipes/fine-tuning/nova/nova_lite_g5_g6_12x_gpu_lora_sft.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_lite_g5_g6_12x_gpu_lora_sft.yaml
@@ -1,0 +1,46 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.12xlarge and g6.12xlarge instance types.
+
+## Run config
+run:
+  name: "my-lora-run"             # A descriptive name for your training job
+  model_type: "amazon.nova-lite-v1:0:300k"  # Model variant specification, do not change
+  model_name_or_path: "nova-lite/prod"      # Base model path, do not change
+  replicas: 1                     # Number of compute instances for training, allowed value is 1
+  data_s3_path: ""                # Customer data path
+  output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+  max_length: 8192               # Maximum context window size (tokens). Should be between [1024, 8192] and multiple of 1024.
+  global_batch_size: 64           # Global batch size, allowed values are 16, 32, 64
+
+  trainer:
+    max_epochs: 2                # Number of training epochs
+
+  model:
+    hidden_dropout: 0.0          # Dropout for hidden states, must be between 0.0 and 1.0
+    attention_dropout: 0.0       # Dropout for attention weights, must be between 0.0 and 1.0
+    ffn_dropout: 0.0             # Dropout for feed-forward networks, must be between 0.0 and 1.0
+
+    optim:
+      lr: 1e-5                 # Learning rate
+      name: distributed_fused_adam  # Optimizer algorithm, do not change
+      adam_w_mode: true        # Enable AdamW mode
+      eps: 1e-06               # Epsilon for numerical stability
+      weight_decay: 0.0        # L2 regularization strength, must be between 0.0 and 1.0
+      betas:                   # Adam optimizer betas, must be between 0.0 and 1.0
+        - 0.9
+        - 0.999
+      sched:
+        warmup_steps: 10     # Learning rate warmup steps
+        constant_steps: 0    # Steps at constant learning rate
+        min_lr: 1e-6         # Minimum learning rate
+
+    peft:
+      peft_scheme: "lora"      # Enable LoRA for parameter-efficient fine-tuning
+      lora_tuning:
+        loraplus_lr_ratio: 8.0  # LoRA+ learning rate scaling factor, must be between 0.0 and 100.0
+        alpha: 32            # Scaling factor for LoRA weights. Allowed values are 32, 64, 96, 128, 160 and 192
+        adapter_dropout: 0.01  # Regularization for LoRA parameters. Must be between 0.0 and 1.0

--- a/recipes_collection/recipes/fine-tuning/nova/nova_lite_g5_g6_48x_gpu_lora_dpo.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_lite_g5_g6_48x_gpu_lora_dpo.yaml
@@ -1,0 +1,49 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.48xlarge and g6.48xlarge instance types.
+
+## Run config
+run:
+    name: "my-lora-run"             # A descriptive name for your training job
+    model_type: "amazon.nova-lite-v1:0:300k"  # Model variant specification, do not change
+    model_name_or_path: "nova-lite/prod"      # Base model path, do not change
+    replicas: 1                     # Number of compute instances for training. All supported values: {1}
+    data_s3_path: ""                # Customer data path
+    output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+    max_length: 4096               # Maximum context window size (tokens). Should be between [1024, 4096] and multiple of 1024.
+    global_batch_size: 64           # Total samples per step. Limits: {16, 32, 64}
+
+    trainer:
+        max_epochs: 2               # Number of training epochs
+
+    model:
+        hidden_dropout: 0.0          # Dropout for hidden states. Limits: [0.0, 1.0]
+        attention_dropout: 0.0       # Dropout for attention weights. Limits: [0.0, 1.0]
+        ffn_dropout: 0.0             # Dropout for feed-forward networks. Limits: [0.0, 1.0]
+
+        optim:
+            lr: 1e-5                 # Learning rate
+            name: distributed_fused_adam  # Optimizer algorithm, do not change
+            adam_w_mode: true        # Enable AdamW mode
+            eps: 1e-08               # Epsilon for numerical stability
+            weight_decay: 0.01       # L2 regularization strength
+            betas:                   # Adam optimizer betas. Limits: [0.0, 1.0]
+                - 0.9
+                - 0.999
+            sched:
+                warmup_steps: 10     # Learning rate warmup steps
+                constant_steps: 0    # Steps at constant learning rate
+                min_lr: 1e-6         # Minimum learning rate
+
+        dpo_cfg:
+            beta: 0.1               # Strength of preference enforcement. Limits: [0.001, 0.5]
+
+        peft:
+            peft_scheme: "lora"      # Enable LoRA for parameter-efficient fine-tuning
+            lora_tuning:
+                loraplus_lr_ratio: 20.0  # LoRA+ learning rate scaling factor. Limits: [0.0, 100.0]
+                alpha: 64            # Scaling factor for LoRA weights. [32, 64, 96, 128, 160, 192]
+                adapter_dropout: 0.01  # Regularization for LoRA parameters. Limits: [0.0, 1.0]

--- a/recipes_collection/recipes/fine-tuning/nova/nova_lite_g5_g6_48x_gpu_lora_sft.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_lite_g5_g6_48x_gpu_lora_sft.yaml
@@ -1,12 +1,12 @@
 # Note:
 # This recipe is currently supported only on Amazon SageMaker training jobs.
-
+# This recipe can run on g5.48xlarge and g6.48xlarge instance types.
 
 ## Run config
 run:
   name: "my-lora-run"             # A descriptive name for your training job
-  model_type: "amazon.nova-micro-v1:0:128k"  # Model variant specification, do not change
-  model_name_or_path: "nova-micro/prod"      # Base model path, do not change
+  model_type: "amazon.nova-lite-v1:0:300k"  # Model variant specification, do not change
+  model_name_or_path: "nova-lite/prod"      # Base model path, do not change
   replicas: 1                     # Number of compute instances for training, allowed value is 1
   data_s3_path: ""                # Customer data path
   output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs

--- a/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_12x_gpu_lora_dpo.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_12x_gpu_lora_dpo.yaml
@@ -1,0 +1,49 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.12xlarge and g6.12xlarge instance types.
+
+## Run config
+run:
+    name: "my-lora-run"             # A descriptive name for your training job
+    model_type: "amazon.nova-micro-v1:0:128k"  # Model variant specification, do not change
+    model_name_or_path: "nova-micro/prod"      # Base model path, do not change
+    replicas: 1                      # Number of compute instances for training. All supported values: {1}
+    data_s3_path: ""                # Customer data path
+    output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+    max_length: 4096               # Maximum context window size (tokens). Should be between [1024, 4096] and multiple of 1024.
+    global_batch_size: 64           # Total samples per step. Limits: {16, 32, 64}
+
+    trainer:
+        max_epochs: 2               # Number of training epochs
+
+    model:
+        hidden_dropout: 0.0          # Dropout for hidden states. Limits: [0.0, 1.0]
+        attention_dropout: 0.0       # Dropout for attention weights. Limits: [0.0, 1.0]
+        ffn_dropout: 0.0             # Dropout for feed-forward networks. Limits: [0.0, 1.0]
+
+        optim:
+            lr: 1e-5                 # Learning rate
+            name: distributed_fused_adam  # Optimizer algorithm, do not change
+            adam_w_mode: true        # Enable AdamW mode
+            eps: 1e-08               # Epsilon for numerical stability
+            weight_decay: 0.01       # L2 regularization strength
+            betas:                   # Adam optimizer betas. Limits: [0.0, 1.0]
+                - 0.9
+                - 0.999
+            sched:
+                warmup_steps: 10     # Learning rate warmup steps
+                constant_steps: 0    # Steps at constant learning rate
+                min_lr: 1e-6         # Minimum learning rate
+
+        dpo_cfg:
+            beta: 0.1               # Strength of preference enforcement. Limits: [0.001, 0.5]
+
+        peft:
+            peft_scheme: "lora"      # Enable LoRA for parameter-efficient fine-tuning
+            lora_tuning:
+                loraplus_lr_ratio: 20.0  # LoRA+ learning rate scaling factor. Limits: [0.0, 100.0]
+                alpha: 64            # Scaling factor for LoRA weights. [32, 64, 96, 128, 160, 192]
+                adapter_dropout: 0.01  # Regularization for LoRA parameters. Limits: [0.0, 1.0]

--- a/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_12x_gpu_lora_sft.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_12x_gpu_lora_sft.yaml
@@ -1,0 +1,46 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.12xlarge and g6.12xlarge instance types.
+
+## Run config
+run:
+  name: "my-lora-run"             # A descriptive name for your training job
+  model_type: "amazon.nova-micro-v1:0:128k"  # Model variant specification, do not change
+  model_name_or_path: "nova-micro/prod"      # Base model path, do not change
+  replicas: 1                     # Number of compute instances for training, allowed value is 1
+  data_s3_path: ""                # Customer data path
+  output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+  max_length: 8192               # Maximum context window size (tokens). Should be between [1024, 8192] and multiple of 1024.
+  global_batch_size: 64           # Global batch size, allowed values are 16, 32, 64
+
+  trainer:
+    max_epochs: 2                # Number of training epochs
+
+  model:
+    hidden_dropout: 0.0          # Dropout for hidden states, must be between 0.0 and 1.0
+    attention_dropout: 0.0       # Dropout for attention weights, must be between 0.0 and 1.0
+    ffn_dropout: 0.0             # Dropout for feed-forward networks, must be between 0.0 and 1.0
+
+    optim:
+      lr: 1e-5                 # Learning rate
+      name: distributed_fused_adam  # Optimizer algorithm, do not change
+      adam_w_mode: true        # Enable AdamW mode
+      eps: 1e-06               # Epsilon for numerical stability
+      weight_decay: 0.0        # L2 regularization strength, must be between 0.0 and 1.0
+      betas:                   # Adam optimizer betas, must be between 0.0 and 1.0
+        - 0.9
+        - 0.999
+      sched:
+        warmup_steps: 10     # Learning rate warmup steps
+        constant_steps: 0    # Steps at constant learning rate
+        min_lr: 1e-6         # Minimum learning rate
+
+    peft:
+      peft_scheme: "lora"      # Enable LoRA for parameter-efficient fine-tuning
+      lora_tuning:
+        loraplus_lr_ratio: 8.0  # LoRA+ learning rate scaling factor, must be between 0.0 and 100.0
+        alpha: 32            # Scaling factor for LoRA weights. Allowed values are 32, 64, 96, 128, 160 and 192
+        adapter_dropout: 0.01  # Regularization for LoRA parameters. Must be between 0.0 and 1.0

--- a/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_48x_gpu_lora_dpo.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_48x_gpu_lora_dpo.yaml
@@ -1,0 +1,49 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.48xlarge and g6.48xlarge instance types.
+
+## Run config
+run:
+    name: "my-lora-run"             # A descriptive name for your training job
+    model_type: "amazon.nova-micro-v1:0:128k"  # Model variant specification, do not change
+    model_name_or_path: "nova-micro/prod"      # Base model path, do not change
+    replicas: 1                      # Number of compute instances for training. allowed value is 1
+    data_s3_path: ""                # Customer data path
+    output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+    max_length: 4096               # Maximum context window size (tokens). Should be between [1024, 4096] and multiple of 1024.
+    global_batch_size: 64           # Total samples per step. Limits: {16, 32, 64}
+
+    trainer:
+        max_epochs: 2               # Number of training epochs
+
+    model:
+        hidden_dropout: 0.0          # Dropout for hidden states. Limits: [0.0, 1.0]
+        attention_dropout: 0.0       # Dropout for attention weights. Limits: [0.0, 1.0]
+        ffn_dropout: 0.0             # Dropout for feed-forward networks. Limits: [0.0, 1.0]
+
+        optim:
+            lr: 1e-5                 # Learning rate
+            name: distributed_fused_adam  # Optimizer algorithm, do not change
+            adam_w_mode: true        # Enable AdamW mode
+            eps: 1e-08               # Epsilon for numerical stability
+            weight_decay: 0.01       # L2 regularization strength
+            betas:                   # Adam optimizer betas. Limits: [0.0, 1.0]
+                - 0.9
+                - 0.999
+            sched:
+                warmup_steps: 10     # Learning rate warmup steps
+                constant_steps: 0    # Steps at constant learning rate
+                min_lr: 1e-6         # Minimum learning rate
+
+        dpo_cfg:
+            beta: 0.1               # Strength of preference enforcement. Limits: [0.001, 0.5]
+
+        peft:
+            peft_scheme: "lora"      # Enable LoRA for parameter-efficient fine-tuning
+            lora_tuning:
+                loraplus_lr_ratio: 20.0  # LoRA+ learning rate scaling factor. Limits: [0.0, 100.0]
+                alpha: 64            # Scaling factor for LoRA weights. [32, 64, 96, 128, 160, 192]
+                adapter_dropout: 0.01  # Regularization for LoRA parameters. Limits: [0.0, 1.0]

--- a/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_48x_gpu_lora_sft.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_48x_gpu_lora_sft.yaml
@@ -1,0 +1,46 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.48xlarge and g6.48xlarge instance types.
+
+## Run config
+run:
+  name: "my-lora-run"             # A descriptive name for your training job
+  model_type: "amazon.nova-micro-v1:0:128k"  # Model variant specification, do not change
+  model_name_or_path: "nova-micro/prod"      # Base model path, do not change
+  replicas: 1                     # Number of compute instances for training, allowed value is 1
+  data_s3_path: ""                # Customer data path
+  output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+  max_length: 8192               # Maximum context window size (tokens). Should be between [1024, 8192] and multiple of 1024.
+  global_batch_size: 64           # Global batch size, allowed values are 16, 32, 64
+
+  trainer:
+    max_epochs: 2                # Number of training epochs
+
+  model:
+    hidden_dropout: 0.0          # Dropout for hidden states, must be between 0.0 and 1.0
+    attention_dropout: 0.0       # Dropout for attention weights, must be between 0.0 and 1.0
+    ffn_dropout: 0.0             # Dropout for feed-forward networks, must be between 0.0 and 1.0
+
+    optim:
+      lr: 1e-5                 # Learning rate
+      name: distributed_fused_adam  # Optimizer algorithm, do not change
+      adam_w_mode: true        # Enable AdamW mode
+      eps: 1e-06               # Epsilon for numerical stability
+      weight_decay: 0.0        # L2 regularization strength, must be between 0.0 and 1.0
+      betas:                   # Adam optimizer betas, must be between 0.0 and 1.0
+        - 0.9
+        - 0.999
+      sched:
+        warmup_steps: 10     # Learning rate warmup steps
+        constant_steps: 0    # Steps at constant learning rate
+        min_lr: 1e-6         # Minimum learning rate
+
+    peft:
+      peft_scheme: "lora"      # Enable LoRA for parameter-efficient fine-tuning
+      lora_tuning:
+        loraplus_lr_ratio: 8.0  # LoRA+ learning rate scaling factor, must be between 0.0 and 100.0
+        alpha: 32            # Scaling factor for LoRA weights. Allowed values are 32, 64, 96, 128, 160 and 192
+        adapter_dropout: 0.01  # Regularization for LoRA parameters. Must be between 0.0 and 1.0

--- a/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_48x_gpu_sft.yaml
+++ b/recipes_collection/recipes/fine-tuning/nova/nova_micro_g5_g6_48x_gpu_sft.yaml
@@ -1,0 +1,42 @@
+# Note:
+# This recipe is currently supported only on Amazon SageMaker training jobs.
+# This recipe can run on g5.48xlarge and g6.48xlarge instance types.
+
+## Run config
+run:
+  name: "my-fullrank-run"             # A descriptive name for your training job
+  model_type: "amazon.nova-micro-v1:0:128k"  # Model variant specification, do not change
+  model_name_or_path: "nova-micro/prod"      # Base model path, do not change
+  replicas: 1                     # Number of compute instances for training, allowed value is 1
+  data_s3_path: ""                # Customer data path
+  output_s3_path: ""              # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with standard Sagemaker Training jobs
+
+## Training specific configs
+training_config:
+  max_length: 8192               # Maximum context window size (tokens). Should be between [1024, 8192] and multiple of 1024.
+  global_batch_size: 64           # Global batch size, allowed values are 16, 32, 64.
+
+  trainer:
+    max_epochs: 2                # Number of training epochs
+
+  model:
+    hidden_dropout: 0.0          # Dropout for hidden states, must be between 0.0 and 1.0
+    attention_dropout: 0.0       # Dropout for attention weights, must be between 0.0 and 1.0
+    ffn_dropout: 0.0             # Dropout for feed-forward networks, must be between 0.0 and 1.0
+
+    optim:
+      lr: 1e-5                 # Learning rate
+      name: distributed_fused_adam  # Optimizer algorithm, do not change
+      adam_w_mode: true        # Enable AdamW mode
+      eps: 1e-06               # Epsilon for numerical stability
+      weight_decay: 0.0        # L2 regularization strength, must be between 0.0 and 1.0
+      betas:                   # Adam optimizer betas, must be between 0.0 and 1.0
+        - 0.9
+        - 0.999
+      sched:
+        warmup_steps: 10     # Learning rate warmup steps
+        constant_steps: 0    # Steps at constant learning rate
+        min_lr: 1e-6         # Minimum learning rate, must be lower than lr
+
+    peft:
+      peft_scheme: null      # Disables PEFT


### PR DESCRIPTION
## Description

### Motivation
Currently Nova SFT and DPO recipes can run on p5 instances only, this change will expand this support to other instance types.

### Changes
* Add Nova recipes for g5/g6 instance type for Micro/lite model types

### Testing
python -m pytest

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [x] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [ ] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [ ] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [x] I have run `pytest` on my code and all unit tests passed.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
