### PR TITLE
Update bring your own metrics on eval recipe

### DIFF
--- a/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-lite-byod-eval-job
   model_type: amazon.nova-lite-v1:0:300k
   model_name_or_path: s3://escrow_bucket/model_location or nova-lite/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # Leave empty for Sagemaker Training job, required for Sagemaker Hyperpod job
   output_s3_path: "" # (Required) Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 
@@ -13,7 +13,19 @@ evaluation:
 
 # Optional Inference configs
 inference:
-  max_new_tokens: 12000
+  max_new_tokens: 8196
   top_k: -1
   top_p: 1.0
   temperature: 0
+
+# =============================================================================
+# OPTIONAL: Bring Your Own Metrics Configuration
+# Uncomment and modify the section below to enable custom metrics processing
+# =============================================================================
+# processor:
+#   lambda_arn: arn:aws:lambda:us-west-2:<account_id>:function:<name>
+#   preprocessing:
+#     enabled: true
+#   postprocessing:
+#     enabled: true
+#   aggregation: macro-average

--- a/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -19,7 +19,7 @@ inference:
   temperature: 0
 
 # =============================================================================
-# OPTIONAL: Bring Your Own Metrics Configuration
+# OPTIONAL: Bring Your Own Metrics Configuration, only works for SMTJ
 # Uncomment and modify the section below to enable custom metrics processing
 # =============================================================================
 # processor:

--- a/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -28,4 +28,4 @@ inference:
 #     enabled: true
 #   postprocessing:
 #     enabled: true
-#   aggregation: macro-average
+#   aggregation: average

--- a/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_general_multi_modal_benchmark_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_general_multi_modal_benchmark_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-lite-mmmu-eval-job
   model_type: amazon.nova-lite-v1:0:300k
   model_name_or_path: s3://escrow_bucket/model_location or nova-lite/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # unmodifiable
   output_s3_path: "" # (Required) Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 

--- a/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_general_text_benchmark_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_general_text_benchmark_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-lite-mmlu-eval-job
   model_type: amazon.nova-lite-v1:0:300k
   model_name_or_path: s3://escrow_bucket/model_location or nova-lite/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # unmodifiable
   output_s3_path: "" # (Required) Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 

--- a/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_llm_judge_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_lite_p5_48xl_llm_judge_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-lite-llm-judge-eval-job
   model_type: amazon.nova-lite-v1:0:300k # unmodifiable
   model_name_or_path: s3://escrow_bucket/model_location or nova-lite/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # Leave empty for Sagemaker Training job, required for Sagemaker Hyperpod job
   output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 

--- a/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-micro-byod-eval-job
   model_type: amazon.nova-micro-v1:0:128k
   model_name_or_path: s3://escrow_bucket/model_location or nova-micro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # Leave empty for Sagemaker Training job, required for Sagemaker Hyperpod job
   output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 
@@ -13,7 +13,19 @@ evaluation:
 
 # Optional Inference configs
 inference:
-  max_new_tokens: 12000
+  max_new_tokens: 8196
   top_k: -1
   top_p: 1.0
   temperature: 0
+
+# =============================================================================
+# OPTIONAL: Bring Your Own Metrics Configuration
+# Uncomment and modify the section below to enable custom metrics processing
+# =============================================================================
+# processor:
+#   lambda_arn: arn:aws:lambda:us-west-2:<account_id>:function:<name>
+#   preprocessing:
+#     enabled: true
+#   postprocessing:
+#     enabled: true
+#   aggregation: macro-average

--- a/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -19,7 +19,7 @@ inference:
   temperature: 0
 
 # =============================================================================
-# OPTIONAL: Bring Your Own Metrics Configuration
+# OPTIONAL: Bring Your Own Metrics Configuration, only works for SMTJ
 # Uncomment and modify the section below to enable custom metrics processing
 # =============================================================================
 # processor:

--- a/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -28,4 +28,4 @@ inference:
 #     enabled: true
 #   postprocessing:
 #     enabled: true
-#   aggregation: macro-average
+#   aggregation: average

--- a/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_general_text_benchmark_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_general_text_benchmark_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-micro-mmlu-eval-job
   model_type: amazon.nova-micro-v1:0:128k # modifiable
   model_name_or_path: s3://escrow_bucket/model_location or nova-micro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # unmodifiable
   output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 

--- a/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_llm_judge_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_micro_p5_48xl_llm_judge_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-micro-llm-judge-eval-job
   model_type: amazon.nova-micro-v1:0:128k # unmodifiable
   model_name_or_path: s3://escrow_bucket/model_location or nova-micro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # Leave empty for Sagemaker Training job, required for Sagemaker Hyperpod job
   output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 

--- a/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-pro-byod-eval-job
   model_type: amazon.nova-pro-v1:0:300k
   model_name_or_path: s3://escrow_bucket/model_location or nova-pro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # Leave empty for Sagemaker Training job, required for Sagemaker Hyperpod job
   output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 
@@ -13,7 +13,19 @@ evaluation:
 
 # Optional Inference configs
 inference:
-  max_new_tokens: 12000
+  max_new_tokens: 8196
   top_k: -1
   top_p: 1.0
   temperature: 0
+
+# =============================================================================
+# OPTIONAL: Bring Your Own Metrics Configuration
+# Uncomment and modify the section below to enable custom metrics processing
+# =============================================================================
+# processor:
+#   lambda_arn: arn:aws:lambda:us-west-2:<account_id>:function:<name>
+#   preprocessing:
+#     enabled: true
+#   postprocessing:
+#     enabled: true
+#   aggregation: macro-average

--- a/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -19,7 +19,7 @@ inference:
   temperature: 0
 
 # =============================================================================
-# OPTIONAL: Bring Your Own Metrics Configuration
+# OPTIONAL: Bring Your Own Metrics Configuration, only works for SMTJ
 # Uncomment and modify the section below to enable custom metrics processing
 # =============================================================================
 # processor:

--- a/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_bring_your_own_dataset_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_bring_your_own_dataset_eval.yaml
@@ -28,4 +28,4 @@ inference:
 #     enabled: true
 #   postprocessing:
 #     enabled: true
-#   aggregation: macro-average
+#   aggregation: average

--- a/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_general_multi_modal_benchmark_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_general_multi_modal_benchmark_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-pro-mmmu-eval-job
   model_type: amazon.nova-pro-v1:0:300k
   model_name_or_path: s3://escrow_bucket/model_location or nova-pro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # unmodifiable
   output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
 

--- a/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_general_text_benchmark_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_general_text_benchmark_eval.yaml
@@ -2,9 +2,9 @@ run:
   name: nova-pro-mmlu-eval-job
   model_type: amazon.nova-pro-v1:0:300k
   model_name_or_path: s3://escrow_bucket/model_location or nova-pro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # unmodifiable
-  output_s3_path: "" # Output artifact path, Sagemaker Hyperpod job-specific configuration - not compatible with Sagemaker Training jobs
+  output_s3_path: "" # Output artifact path, only use for Sagemaker Hyperpod job, not for Sagemaker Training job
 
 evaluation:
   task: mmlu

--- a/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_llm_judge_eval.yaml
+++ b/recipes_collection/recipes/evaluation/nova/nova_pro_p5_48xl_llm_judge_eval.yaml
@@ -2,7 +2,7 @@ run:
   name: nova-pro-llm-judge-eval-job
   model_type: amazon.nova-pro-v1:0:300k # unmodifiable
   model_name_or_path: s3://escrow_bucket/model_location or nova-pro/prod # modifiable
-  replicas: 1 # unmodifiable
+  replicas: 1 # modifiable for Sagemaker Training job, unmodifiable for Sagemaker Hyperpod job
   data_s3_path: "" # Leave empty for Sagemaker Training job, required for Sagemaker Hyperpod job
   output_s3_path: "" # Output artifact path, only use for Sagemaker Hyperpod job, not for Sagemaker Training job
 


### PR DESCRIPTION
## Description
This change enable bring your own metrics feature, multi-node support on Nova eval recipe.These features only applies on Sagemaker training job as of now, Sagemaker hyperpod is not within the scope.

### Motivation
We plan to launch the bring your own metrics feature on Nova Evaluation on SMTJ by 9/30.

### Changes
* Change to support `processor` in BYOD recipe 


### Testing
* Run unit tests and passed

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [x] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [ ] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [ ] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [x] I have run `pytest` on my code and all unit tests passed.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
