### PR TITLE
feat: Add per-service instance type support in launcher

### DIFF
--- a/launcher/nova/k8s_templates/RFT/templates/hub.yaml
+++ b/launcher/nova/k8s_templates/RFT/templates/hub.yaml
@@ -1,5 +1,6 @@
 {{- $root := .Values }}
 {{ $config := .Values.trainingConfig }}
+{{- $svcLS := default $config.labelSelector $config.hub.labelSelector }}
 
 apiVersion: v1
 kind: Service
@@ -82,13 +83,13 @@ spec:
                 operator: In
                 values: ["gpu-intensive-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -97,11 +98,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}
@@ -234,13 +235,13 @@ spec:
                 operator: In
                 values: ["gpu-intensive-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -249,11 +250,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}

--- a/launcher/nova/k8s_templates/RFT/templates/nats-server.yaml
+++ b/launcher/nova/k8s_templates/RFT/templates/nats-server.yaml
@@ -1,5 +1,6 @@
 {{- $root := .Values }}
 {{ $config := .Values.trainingConfig }}
+{{- $svcLS := default $config.labelSelector $config.natsServer.labelSelector }}
 
 ---
 # Source: storm-rl/templates/nats-server.yaml
@@ -218,13 +219,13 @@ spec:
                 operator: In
                 values: ["gpu-intensive-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -233,11 +234,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}

--- a/launcher/nova/k8s_templates/RFT/templates/prompt-rbs.yaml
+++ b/launcher/nova/k8s_templates/RFT/templates/prompt-rbs.yaml
@@ -1,5 +1,6 @@
 {{- $root := .Values }}
 {{- $config := .Values.trainingConfig }}
+{{- $svcLS := default $config.labelSelector $config.prompter.labelSelector }}
 ---
 apiVersion: v1
 kind: Service
@@ -106,13 +107,13 @@ spec:
                 operator: In
                 values: ["gpu-intensive-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -121,11 +122,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}
@@ -276,13 +277,13 @@ spec:
                 operator: In
                 values: ["gpu-intensive-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -291,11 +292,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}

--- a/launcher/nova/k8s_templates/RFT/templates/redis.yaml
+++ b/launcher/nova/k8s_templates/RFT/templates/redis.yaml
@@ -1,5 +1,6 @@
 {{- $root := .Values }}
 {{ $config := .Values.trainingConfig }}
+{{- $svcLS := default $config.labelSelector $config.redis.labelSelector }}
 
 {{- if .Values.trainingConfig.redis.enabled }}
 apiVersion: v1
@@ -75,13 +76,13 @@ spec:
                 operator: In
                 values: ["gpu-intensive-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -90,11 +91,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}

--- a/launcher/nova/k8s_templates/RFT/templates/training.yaml
+++ b/launcher/nova/k8s_templates/RFT/templates/training.yaml
@@ -1,5 +1,6 @@
 {{- $root := .Values }}
 {{ $config := .Values.trainingConfig }}
+{{- $svcLS := default $config.labelSelector $config.training.labelSelector }}
 
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
@@ -49,13 +50,13 @@ spec:
                     operator: In
                     values: ["cpu-only-{{ .Values.trainingConfig.jobName }}"]
                 topologyKey: kubernetes.io/hostname
-            {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+            {{- if (or $svcLS.required $svcLS.preferred) }}
             nodeAffinity:
-              {{- if $config.labelSelector.required }}
+              {{- if $svcLS.required }}
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
-                    {{- range $key, $values := $config.labelSelector.required }}
+                    {{- range $key, $values := $svcLS.required }}
                     - key: {{ $key | quote }}
                       operator: In
                       values:
@@ -64,11 +65,11 @@ spec:
                         {{- end}}
                     {{- end }}
               {{- end }}
-              {{- if $config.labelSelector.preferred }}
+              {{- if $svcLS.preferred }}
               {{- $index := 0 }}
               preferredDuringSchedulingIgnoredDuringExecution:
-                {{- range $key, $values := $config.labelSelector.preferred }}
-                - weight: {{ index $config.labelSelector.weights $index }}
+                {{- range $key, $values := $svcLS.preferred }}
+                - weight: {{ index $svcLS.weights $index }}
                   preference:
                     matchExpressions:
                       - key: {{ $key | quote }}
@@ -173,13 +174,13 @@ spec:
                     operator: In
                     values: ["cpu-only-{{ .Values.trainingConfig.jobName }}"]
                 topologyKey: kubernetes.io/hostname
-            {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+            {{- if (or $svcLS.required $svcLS.preferred) }}
             nodeAffinity:
-              {{- if $config.labelSelector.required }}
+              {{- if $svcLS.required }}
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                   - matchExpressions:
-                    {{- range $key, $values := $config.labelSelector.required }}
+                    {{- range $key, $values := $svcLS.required }}
                     - key: {{ $key | quote }}
                       operator: In
                       values:
@@ -188,11 +189,11 @@ spec:
                         {{- end}}
                     {{- end }}
               {{- end }}
-              {{- if $config.labelSelector.preferred }}
+              {{- if $svcLS.preferred }}
               {{- $index := 0 }}
               preferredDuringSchedulingIgnoredDuringExecution:
-                {{- range $key, $values := $config.labelSelector.preferred }}
-                - weight: {{ index $config.labelSelector.weights $index }}
+                {{- range $key, $values := $svcLS.preferred }}
+                - weight: {{ index $svcLS.weights $index }}
                   preference:
                     matchExpressions:
                       - key: {{ $key | quote }}

--- a/launcher/nova/k8s_templates/RFT/templates/vllm-generation.yaml
+++ b/launcher/nova/k8s_templates/RFT/templates/vllm-generation.yaml
@@ -1,5 +1,6 @@
 {{- $root := .Values }}
 {{ $config := .Values.trainingConfig }}
+{{- $svcLS := default $config.labelSelector $config.vllmGeneration.labelSelector }}
 
 apiVersion: v1
 kind: Service
@@ -95,13 +96,13 @@ spec:
                 operator: In
                 values: ["cpu-only-{{ .Values.trainingConfig.jobName }}"]
             topologyKey: kubernetes.io/hostname
-        {{- if (or $config.labelSelector.required $config.labelSelector.preferred) }}
+        {{- if (or $svcLS.required $svcLS.preferred) }}
         nodeAffinity:
-          {{- if $config.labelSelector.required }}
+          {{- if $svcLS.required }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                {{- range $key, $values := $config.labelSelector.required }}
+                {{- range $key, $values := $svcLS.required }}
                 - key: {{ $key | quote }}
                   operator: In
                   values:
@@ -110,11 +111,11 @@ spec:
                     {{- end}}
                 {{- end }}
           {{- end }}
-          {{- if $config.labelSelector.preferred }}
+          {{- if $svcLS.preferred }}
           {{- $index := 0 }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            {{- range $key, $values := $config.labelSelector.preferred }}
-            - weight: {{ index $config.labelSelector.weights $index }}
+            {{- range $key, $values := $svcLS.preferred }}
+            - weight: {{ index $svcLS.weights $index }}
               preference:
                 matchExpressions:
                   - key: {{ $key | quote }}

--- a/launcher/nova/k8s_templates/RFT/values.yaml
+++ b/launcher/nova/k8s_templates/RFT/values.yaml
@@ -47,6 +47,7 @@ trainingConfig:
     instanceType: "ml.p5.48xlarge"
     nodeSelector: null
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       master:
         requests:
@@ -69,6 +70,7 @@ trainingConfig:
     instanceType: "ml.p5.48xlarge"
     nodeSelector: null
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       requests:
         nvidia.com/gpu: "8"
@@ -87,6 +89,7 @@ trainingConfig:
     instanceType: "ml.p5.48xlarge"
     nodeSelector: null
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       requests:
         cpu: "90"
@@ -102,6 +105,7 @@ trainingConfig:
     replicas: 1
     instanceType: "ml.p5.48xlarge"
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       requests:
         cpu: "5"
@@ -117,6 +121,7 @@ trainingConfig:
     replicas: 1
     instanceType: "ml.p5.48xlarge"
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       requests:
         cpu: "85"
@@ -133,6 +138,7 @@ trainingConfig:
     instanceType: "ml.p5.48xlarge"
     nodeSelector: null
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       requests:
         cpu: "30"
@@ -153,6 +159,7 @@ trainingConfig:
     replicas: 1
     instanceType: "ml.p5.48xlarge"
     affinity: null
+    labelSelector: null  # Per-service label selector; falls back to global labelSelector if null
     resources:
       requests:
         cpu: "500m"

--- a/launcher/nova/launchers.py
+++ b/launcher/nova/launchers.py
@@ -187,6 +187,28 @@ def get_device_count_for_instance(instance_type):
     return INSTANCE_TO_DEVICE_COUNT.get(instance_type, 8)
 
 
+def get_instance_types_map(cfg, default_instance_type):
+    """
+    Build a dict mapping service names to their resolved instance types.
+    Falls back to default_instance_type for any service not explicitly listed.
+
+    Returns:
+        dict: e.g. {"training": "ml.p5.48xlarge", "hub": "ml.r6i.24xlarge", ...}
+    """
+    instance_types_cfg = cfg.get("instance_types")
+    if not instance_types_cfg:
+        return {}
+
+    result = {}
+    for service_name, inst_type in instance_types_cfg.items():
+        if inst_type is not None:
+            normalized = str(inst_type)
+            if not normalized.startswith("ml."):
+                normalized = f"ml.{normalized}"
+            result[service_name] = normalized.lower()
+    return result
+
+
 def templatize_K8_container_images(content, recipe_name):
     # Init container for nova sft/dpo recipes
     init_container_image = get_init_container_uri()
@@ -234,6 +256,7 @@ class NovaK8SLauncher:
         self._launch_json = cfg["launch_json"]
         self.instance_type = get_instance_type(cfg)
         self.num_efa_devices = get_num_efa_devices(self.instance_type)
+        self.instance_types_map = get_instance_types_map(cfg, self.instance_type)
         self.recipe_file_path = None
 
     @staticmethod
@@ -261,6 +284,26 @@ class NovaK8SLauncher:
             env_vars["INSTANCE_TYPE"] = self.instance_type
 
         return env_vars
+
+    def _get_instance_type_for_service(self, service_name):
+        """Resolve instance type for a specific service, falling back to the default."""
+        return self.instance_types_map.get(service_name, self.instance_type)
+
+    def _build_label_selector_for_instance(self, instance_type_value):
+        """
+        Build a label selector dict for a specific instance type.
+        Merges user-provided required labels with the mandatory instance type/group labels.
+        """
+        required_instances = {
+            "node.kubernetes.io/instance-type": [instance_type_value],
+            "sagemaker.amazonaws.com/instance-group-type": ["Restricted"],
+        }
+        label_selector = self.cfg.cluster.get("label_selector") or {}
+        required_labels = label_selector.get("required") or {}
+        return {
+            **label_selector,
+            "required": {**required_labels, **required_instances},
+        }
 
     def _prepare_output_dir(self):
         if self._output_dir_k8s_folder.exists():
@@ -315,40 +358,15 @@ class NovaK8SLauncher:
 
     def _get_label_selectors(self):
         """
-        Constructs and returns a dictionary of label selectors required for Nova jobs.
-
-        This method ensures that the returned label selectors always include the required
-        instance types and instance group types necessary for Nova jobs to run on the
-        appropriate hardware. It merges any user-provided required label selectors from
-        the configuration with the hardcoded required labels.
-
-        Returns:
-            dict: A dictionary containing the merged label selectors, with the "required"
-            key including both user-specified and mandatory labels.
+        Constructs and returns a dictionary of label selectors using the default instance type.
+        For per-service label selectors, use _build_label_selector_for_instance directly.
         """
-
-        # Use placeholder for launch_json mode, actual instance type otherwise
         if self._launch_json:
             instance_type_value = "PLACEHOLDER_INSTANCE_TYPE"
         else:
             instance_type_value = self.instance_type
 
-        # Default instance types for required labels
-        # Nova jobs cannot be run on any other instance types apart from these
-        # This is a hard requirement for the Nova jobs to run
-        # on the required hardware.
-        required_instances = {
-            "node.kubernetes.io/instance-type": [instance_type_value],
-            "sagemaker.amazonaws.com/instance-group-type": ["Restricted"],
-        }
-
-        # Handle labelSelector merging safely
-        label_selector = self.cfg.cluster.get("label_selector") or {}
-        required_labels = label_selector.get("required") or {}
-        return {
-            **label_selector,
-            "required": {**required_labels, **required_instances},
-        }
+        return self._build_label_selector_for_instance(instance_type_value)
 
     def _create_launch_json(self, chart_path):
         """
@@ -1147,26 +1165,30 @@ class SMNovaK8SLauncherRFT(NovaK8SLauncher):
         self._write_value_template(values_template)
 
     def _set_efa_resources(self, values_template):
-        """Set EFA device resources for training and vllmGeneration services."""
-        efa_count = self.num_efa_devices
+        """Set EFA device resources for training and vllmGeneration services.
+        Uses per-service instance types to determine correct EFA counts."""
 
-        # Set EFA resources for training service
+        # Training service EFA
+        training_instance = self._get_instance_type_for_service("training") or self.instance_type
+        training_efa = get_num_efa_devices(training_instance)
         if hasattr(values_template.trainingConfig, "training"):
             training_config = values_template.trainingConfig.training
             if hasattr(training_config, "resources"):
                 if hasattr(training_config.resources, "master"):
-                    training_config.resources.master.requests[EFA_RESOURCE_KEY] = efa_count
-                    training_config.resources.master.limits[EFA_RESOURCE_KEY] = efa_count
+                    training_config.resources.master.requests[EFA_RESOURCE_KEY] = training_efa
+                    training_config.resources.master.limits[EFA_RESOURCE_KEY] = training_efa
                 if hasattr(training_config.resources, "worker"):
-                    training_config.resources.worker.requests[EFA_RESOURCE_KEY] = efa_count
-                    training_config.resources.worker.limits[EFA_RESOURCE_KEY] = efa_count
+                    training_config.resources.worker.requests[EFA_RESOURCE_KEY] = training_efa
+                    training_config.resources.worker.limits[EFA_RESOURCE_KEY] = training_efa
 
-        # Set EFA resources for vllmGeneration service
+        # vllmGeneration service EFA
+        vllm_instance = self._get_instance_type_for_service("vllm_generation") or self.instance_type
+        vllm_efa = get_num_efa_devices(vllm_instance)
         if hasattr(values_template.trainingConfig, "vllmGeneration"):
             vllm_config = values_template.trainingConfig.vllmGeneration
             if hasattr(vllm_config, "resources"):
-                vllm_config.resources.requests[EFA_RESOURCE_KEY] = efa_count
-                vllm_config.resources.limits[EFA_RESOURCE_KEY] = efa_count
+                vllm_config.resources.requests[EFA_RESOURCE_KEY] = vllm_efa
+                vllm_config.resources.limits[EFA_RESOURCE_KEY] = vllm_efa
 
     def _map_rft_replica_config(self, values_template):
         """Map replica counts and Redis configuration."""
@@ -1211,23 +1233,55 @@ class SMNovaK8SLauncherRFT(NovaK8SLauncher):
         values_template.image.redis = get_rft_redis_container_uri()
 
     def _map_resource_config(self, values_template):
-        """Map resource configuration
-        Set instance types and apply nodeAffinity to all services."""
+        """Map resource configuration.
+        Set per-service instance types, label selectors, and EFA counts.
+        GPU services (training, vllmGeneration) use GPU instance types.
+        CPU services (hub, prompter, rbs, natsServer, redis) can use CPU instance types."""
 
-        instance_type = self.instance_type or values_template.trainingConfig.defaultResources.instanceType
+        # Service name mapping: values.yaml field name -> instance_types config key
+        service_config_keys = {
+            "training": "training",
+            "vllmGeneration": "vllm_generation",
+            "hub": "hub",
+            "prompter": "prompter",
+            "rbs": "rbs",
+            "natsServer": "nats_server",
+        }
 
-        # Set instance type and apply nodeAffinity to all services
-        services = ["training", "vllmGeneration", "hub", "prompter", "rbs", "natsServer"]
+        default_instance_type = self.instance_type or values_template.trainingConfig.defaultResources.instanceType
 
-        for service_name in services:
-            service = getattr(values_template.trainingConfig, service_name, None)
-            if service:
-                # Set instance type
-                service.instanceType = instance_type
+        for service_field, config_key in service_config_keys.items():
+            service = getattr(values_template.trainingConfig, service_field, None)
+            if not service:
+                continue
+
+            # Resolve instance type: per-service override > default
+            svc_instance_type = self._get_instance_type_for_service(config_key)
+            if svc_instance_type is None:
+                svc_instance_type = default_instance_type
+            service.instanceType = svc_instance_type
+
+            # Build per-service label selector with the service's own instance type
+            if self._launch_json:
+                svc_label_selector = self._build_label_selector_for_instance("PLACEHOLDER_INSTANCE_TYPE")
+            else:
+                svc_label_selector = self._build_label_selector_for_instance(svc_instance_type)
+            service.labelSelector = svc_label_selector
 
         # Apply to redis if enabled
         if hasattr(values_template.trainingConfig, "redis") and values_template.trainingConfig.redis.enabled:
-            values_template.trainingConfig.redis.instanceType = instance_type
+            redis_instance_type = self._get_instance_type_for_service("redis")
+            if redis_instance_type is None:
+                redis_instance_type = default_instance_type
+            values_template.trainingConfig.redis.instanceType = redis_instance_type
+            if self._launch_json:
+                values_template.trainingConfig.redis.labelSelector = self._build_label_selector_for_instance(
+                    "PLACEHOLDER_INSTANCE_TYPE"
+                )
+            else:
+                values_template.trainingConfig.redis.labelSelector = self._build_label_selector_for_instance(
+                    redis_instance_type
+                )
 
     def _to_camel_case(self, snake_str):
         """Convert snake_case to camelCase."""

--- a/recipes_collection/config.yaml
+++ b/recipes_collection/config.yaml
@@ -21,6 +21,21 @@ dry_run: false
 launch_json: false
 
 instance_type: p5.48xlarge
+
+# Per-service instance type overrides for mixed-instance jobs (e.g., RFT).
+# GPU services (training, vllm_generation) default to instance_type above.
+# CPU services (hub, nats_server, prompter, rbs, redis) can use cheaper CPU instances.
+# Example:
+#   instance_types:
+#     training: ml.p5.48xlarge
+#     vllm_generation: ml.p5.48xlarge
+#     hub: ml.r6i.24xlarge
+#     nats_server: ml.r6i.24xlarge
+#     prompter: ml.r6i.24xlarge
+#     rbs: ml.r6i.24xlarge
+#     redis: ml.r6i.24xlarge
+instance_types: null
+
 base_results_dir: null # Location to store the results, checkpoints and logs.
 
 container: null


### PR DESCRIPTION
## Description

### Motivation
Multi-service training jobs (such as RFT/Storm RL) deploy multiple pods with different compute requirement. GPU-intensive services (training, inference) alongside CPU-only orchestration services (messaging, scheduling, reward computation). Currently, all services are scheduled on the same instance type, forcing expensive GPU instances to be used even for lightweight CPU workloads.

This change adds per-service instance type targeting, enabling deployments where a single job spans multiple instance types within the same cluster. GPU services target GPU nodes while CPU services route to cheaper CPU nodes, reducing cost and improving resource utilization.

### Changes
* Added `get_instance_types_map()` function to build a per-service instance type mapping from config
* Added `_get_instance_type_for_service()` method to resolve instance type for each service with fallback to default
* Added `_build_label_selector_for_instance()` method to construct node affinity label selectors per instance type
* Modified `_map_resource_config()` to set per-service `instanceType` and `labelSelector`
* Modified `_set_efa_resources()` to calculate EFA counts per-service based on their target instance type
* Added per-service `labelSelector: null` field to RFT helm values (falls back to global when null)
* Updated RFT helm templates to read per-service label selectors
* Added `instance_types: null` config field to `recipes_collection/config.yaml`

### Testing
Tested on a HyperPod RIG cluster with mixed instance groups:
- GPU IG: ml.p5.48xlarge (training + generation services)
- CPU IG: ml.r6i.32xlarge (orchestration services)

Verified:
- Per-service node affinity correctly routes pods to the intended instance type
- Label selectors include both `node.kubernetes.io/instance-type` and `sagemaker.amazonaws.com/instance-group-type: Restricted`
- Fallback behavior works. Services without explicit `instance_types` entry use the global `instance_type` default
- Cross-instance-type communication works (NATS messaging, HTTP calls between services on different node types)

Usage:
```bash
hyperpod start-job --recipe "fine-tuning/nova/.../RFT/..." \
  --override-parameters '{
    "instance_type": "ml.p5.48xlarge",
    "++instance_types.training": "ml.p5.48xlarge",
    "++instance_types.vllm_generation": "ml.p5.48xlarge",
    "++instance_types.hub": "ml.r6i.32xlarge",
    "++instance_types.prompter": "ml.r6i.32xlarge",
    "++instance_types.rbs": "ml.r6i.32xlarge",
    "++instance_types.nats_server": "ml.r6i.32xlarge",
    "++instance_types.redis": "ml.r6i.32xlarge"
  }'
```

## Merge Checklist
Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request.

### General
 - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [x] I have run `pre-commit run --all-files` on my code. It will check for [this configuration](../.pre-commit-config.yaml).
 - [ ] I have updated any necessary documentation, including [READMEs](../README.md) and API docs (if appropriate)
 - [x] I have verified the licenses used in the license-files artifact generated in the Python License Scan CI check. If the license workflow fails, kindly check the licenses used in the artifact.

### Tests
 - [ ] I have run `pytest` on my code and all unit tests passed.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
